### PR TITLE
Feat: add clinic library, closes #57

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 
 /.husky
+/.clinic
 .env
 yarn.lock
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|json)\"",
     "validate": "yarn format && yarn lint",
     "validate-staged": "lint-staged",
-    "postinstall": "husky install && husky add .husky/pre-commit \"yarn validate-staged\" && husky add .husky/pre-push \"yarn test\""
+    "postinstall": "husky install && husky add .husky/pre-commit \"yarn validate-staged\" && husky add .husky/pre-push \"yarn test\"",
+    "doctor": "clinic doctor --autocannon [ / ] -- node ./src/app.js",
+    "bubble": "clinic bubble --autocannon [ / ] -- node ./src/app.js",
+    "flame": "clinic flame --autocannon [ / ] -- node ./src/app.js"
   },
   "dependencies": {
     "bcrypt": "^5.0.1",


### PR DESCRIPTION
- first part => our already implemented pino logger library can produce logs and save every flow in separate file so maybe we can use these logs to monitor our application
- second part => maybe we can integrate a performance monitoring library to watch and track leaks and downs for functions and also for the connectivity and scalability of the requests and benchmarking

closes #57 